### PR TITLE
feat: Create Product showcase for API controller

### DIFF
--- a/DefaultCQRS/Controllers/ProductController.cs
+++ b/DefaultCQRS/Controllers/ProductController.cs
@@ -1,0 +1,20 @@
+using AlJawad.DefaultCQRS.Controllers;
+using AlJawad.DefaultCQRS.CQRS.Commands;
+using AlJawad.DefaultCQRS.CQRS.Queries;
+using DefaultCQRS.DTOs;
+using DefaultCQRS.Entities;
+using MediatR;
+using AutoMapper;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Caching.Distributed;
+using System.Security.Principal;
+
+namespace DefaultCQRS.Controllers
+{
+    public class ProductController : DefaultCommandControllerBase<long, Product, ProductDto, CreateProductDto, ProductDto, UpdateProductDto>
+    {
+        public ProductController(IMediator mediator, IDistributedCache appCache, IPrincipal httpContextAccessor, IAuthorizationService service, IMapper mapper) : base(mediator, appCache, httpContextAccessor, service, mapper)
+        {
+        }
+    }
+}

--- a/DefaultCQRS/DTOs/CreateProductDto.cs
+++ b/DefaultCQRS/DTOs/CreateProductDto.cs
@@ -1,0 +1,8 @@
+namespace DefaultCQRS.DTOs
+{
+    public class CreateProductDto
+    {
+        public string Name { get; set; }
+        public decimal Price { get; set; }
+    }
+}

--- a/DefaultCQRS/DTOs/ProductDto.cs
+++ b/DefaultCQRS/DTOs/ProductDto.cs
@@ -1,0 +1,9 @@
+namespace DefaultCQRS.DTOs
+{
+    public class ProductDto
+    {
+        public long Id { get; set; }
+        public string Name { get; set; }
+        public decimal Price { get; set; }
+    }
+}

--- a/DefaultCQRS/DTOs/UpdateProductDto.cs
+++ b/DefaultCQRS/DTOs/UpdateProductDto.cs
@@ -1,0 +1,8 @@
+namespace DefaultCQRS.DTOs
+{
+    public class UpdateProductDto
+    {
+        public string Name { get; set; }
+        public decimal Price { get; set; }
+    }
+}

--- a/DefaultCQRS/Data/AppDbContext.cs
+++ b/DefaultCQRS/Data/AppDbContext.cs
@@ -1,0 +1,14 @@
+using DefaultCQRS.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace DefaultCQRS.Data
+{
+    public class AppDbContext : DbContext
+    {
+        public AppDbContext(DbContextOptions<AppDbContext> options) : base(options)
+        {
+        }
+
+        public DbSet<Product> Products { get; set; }
+    }
+}

--- a/DefaultCQRS/DefaultCQRS.csproj
+++ b/DefaultCQRS/DefaultCQRS.csproj
@@ -5,6 +5,16 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
+    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0-preview.3.24172.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0-preview.3.24172.4" />
+  </ItemGroup>
 	
 	<ItemGroup>
 		<ProjectReference Include="..\AlJawad.DefaultCQRS\AlJawad.DefaultCQRS.csproj" />

--- a/DefaultCQRS/Entities/Product.cs
+++ b/DefaultCQRS/Entities/Product.cs
@@ -1,0 +1,10 @@
+using AlJawad.DefaultCQRS.Entities;
+
+namespace DefaultCQRS.Entities
+{
+    public class Product : BaseEntity
+    {
+        public string Name { get; set; }
+        public decimal Price { get; set; }
+    }
+}

--- a/DefaultCQRS/Profiles/ProductProfile.cs
+++ b/DefaultCQRS/Profiles/ProductProfile.cs
@@ -1,0 +1,16 @@
+using AutoMapper;
+using DefaultCQRS.DTOs;
+using DefaultCQRS.Entities;
+
+namespace DefaultCQRS.Profiles
+{
+    public class ProductProfile : Profile
+    {
+        public ProductProfile()
+        {
+            CreateMap<Product, ProductDto>();
+            CreateMap<CreateProductDto, Product>();
+            CreateMap<UpdateProductDto, Product>();
+        }
+    }
+}

--- a/DefaultCQRS/Program.cs
+++ b/DefaultCQRS/Program.cs
@@ -1,6 +1,17 @@
+using AlJawad.DefaultCQRS.CQRS;
+using DefaultCQRS.Data;
+using Microsoft.EntityFrameworkCore;
+using System.Reflection;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
+builder.Services.AddDbContext<AppDbContext>(options =>
+    options.UseSqlite(builder.Configuration.GetConnectionString("DefaultConnection")));
+
+builder.Services.AddAutoMapper(Assembly.GetExecutingAssembly());
+builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(GeneralHandlerInitializer).Assembly));
+builder.Services.AddControllers();
 builder.Services.AddRazorPages();
 
 var app = builder.Build();
@@ -19,8 +30,7 @@ app.UseRouting();
 
 app.UseAuthorization();
 
-app.MapStaticAssets();
-app.MapRazorPages()
-   .WithStaticAssets();
+app.MapControllers();
+app.MapRazorPages();
 
 app.Run();

--- a/DefaultCQRS/appsettings.json
+++ b/DefaultCQRS/appsettings.json
@@ -1,4 +1,7 @@
 {
+  "ConnectionStrings": {
+    "DefaultConnection": "DataSource=app.db;Cache=Shared"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -1,0 +1,27 @@
+# Instructions for building and running the application
+
+## 1. Restore dependencies
+
+```bash
+dotnet restore
+```
+
+## 2. Create migrations
+
+```bash
+dotnet ef migrations add InitialCreate --project DefaultCQRS
+```
+
+## 3. Apply migrations
+
+```bash
+dotnet ef database update --project DefaultCQRS
+```
+
+## 4. Run the application
+
+```bash
+dotnet run --project DefaultCQRS
+```
+
+After running the application, you can access the Swagger UI at `https://localhost:5001/swagger/index.html` to test the API.


### PR DESCRIPTION
This commit introduces a new `ProductController` that extends the `DefaultCommandControllerBase`.

This showcase includes:
- The `Product` entity and its DTOs.
- An `AppDbContext` with a `DbSet<Product>`.
- AutoMapper profiles for mapping between the entity and DTOs.
- Configuration of services in `Program.cs`.
- An `INSTRUCTIONS.md` file with instructions on how to run the application.