### PR TITLE
feat: Add configurable CQRS handlers with override support

### DIFF
--- a/AlJawad.DefaultCQRS/CQRS/EntityHandlersConfiguration.cs
+++ b/AlJawad.DefaultCQRS/CQRS/EntityHandlersConfiguration.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace AlJawad.DefaultCQRS.CQRS
+{
+    public class EntityHandlersConfiguration
+    {
+        public Type CreateCommandHandler { get; set; }
+        public Type CreateCommandValidator { get; set; }
+        public Type UpdateCommandHandler { get; set; }
+        public Type UpdateCommandValidator { get; set; }
+        public Type DeleteCommandHandler { get; set; }
+        public Type AuthorizationHandler { get; set; }
+        public Type IdentifierQueryHandler { get; set; }
+        public Type ListQueryHandler { get; set; }
+        public Type PagedQueryHandler { get; set; }
+    }
+}

--- a/AlJawad.DefaultCQRS/Extensions/ServiceCollectionExtensions.cs
+++ b/AlJawad.DefaultCQRS/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,60 @@
+using AlJawad.DefaultCQRS.CQRS;
+using AlJawad.DefaultCQRS.CQRS.Behaviors;
+using AlJawad.DefaultCQRS.CQRS.Commands;
+using AlJawad.DefaultCQRS.CQRS.Handlers;
+using AlJawad.DefaultCQRS.CQRS.Permissions;
+using AlJawad.DefaultCQRS.CQRS.Queries;
+using AlJawad.DefaultCQRS.Interfaces;
+using AlJawad.DefaultCQRS.Models.Responses;
+using AlJawad.DefaultCQRS.UnitOfWork;
+using MediatR;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+
+namespace AlJawad.DefaultCQRS.Extensions
+{
+    public static class ServiceCollectionExtensions
+    {
+        public static void AddEntityDynamicConfiguration<TEntityModel, TKeyModel, TCreateModel, TUpdateModel, TReadModel, TmpAuthorizationHandler>(this IServiceCollection services, IConfiguration Configuration, Action<EntityHandlersConfiguration> options = null)
+             where TEntityModel : class, IHaveIdentifier<TKeyModel>, new()
+             where TReadModel : class
+             where TmpAuthorizationHandler : AuthorizationHandler<BaseRequirement<TEntityModel, TKeyModel>>
+        {
+
+            var handlersConfiguration = new EntityHandlersConfiguration();
+            options?.Invoke(handlersConfiguration);
+
+            #region App services Scope and Transient
+
+            var createCommandHandler = handlersConfiguration.CreateCommandHandler ?? typeof(EntityCreateCommandHandler<IUnitOfWork, TEntityModel, TKeyModel, TCreateModel, TReadModel>);
+            services.AddTransient(typeof(IRequestHandler<EntityCreateCommand<TCreateModel, Response<TReadModel>>, Response<TReadModel>>), createCommandHandler);
+
+            var createCommandValidator = handlersConfiguration.CreateCommandValidator ?? typeof(ValidateEntityModelCommandBehavior<TCreateModel, TReadModel>);
+            services.AddTransient(typeof(IPipelineBehavior<EntityCreateCommand<TCreateModel, Response<TReadModel>>, Response<TReadModel>>), createCommandValidator);
+
+            var updateCommandHandler = handlersConfiguration.UpdateCommandHandler ?? typeof(EntityUpdateCommandHandler<IUnitOfWork, TEntityModel, TKeyModel, TUpdateModel, TReadModel>);
+            services.AddTransient(typeof(IRequestHandler<EntityUpdateCommand<TKeyModel, TUpdateModel, Response<TReadModel>>, Response<TReadModel>>), updateCommandHandler);
+
+            var updateCommandValidator = handlersConfiguration.UpdateCommandValidator ?? typeof(ValidateEntityModelCommandBehavior<TUpdateModel, TReadModel>);
+            services.AddTransient(typeof(IPipelineBehavior<EntityUpdateCommand<TKeyModel, TUpdateModel, Response<TReadModel>>, Response<TReadModel>>), updateCommandValidator);
+
+            var deleteCommandHandler = handlersConfiguration.DeleteCommandHandler ?? typeof(EntityDeleteCommandHandler<IUnitOfWork, TEntityModel, TKeyModel, TReadModel>);
+            services.AddTransient(typeof(IRequestHandler<EntityDeleteCommand<TKeyModel, Response<TReadModel>>, Response<TReadModel>>), deleteCommandHandler);
+
+            var authorizationHandler = handlersConfiguration.AuthorizationHandler ?? typeof(TmpAuthorizationHandler);
+            services.AddTransient(typeof(IAuthorizationHandler), authorizationHandler);
+
+            var identifierQueryHandler = handlersConfiguration.IdentifierQueryHandler ?? typeof(EntityIdentifierQueryHandler<IUnitOfWork, TEntityModel, TKeyModel, TReadModel>);
+            services.AddScoped(typeof(IRequestHandler<EntityIdentifierQuery<TKeyModel, Response<TReadModel>>, Response<TReadModel>>), identifierQueryHandler);
+
+            var listQueryHandler = handlersConfiguration.ListQueryHandler ?? typeof(EntityListQueryHandler<IUnitOfWork, TEntityModel, TReadModel>);
+            services.AddScoped(typeof(IRequestHandler<EntityListQuery<ResponseArray<TReadModel>>, ResponseArray<TReadModel>>), listQueryHandler);
+
+            var pagedQueryHandler = handlersConfiguration.PagedQueryHandler ?? typeof(EntityPagedQueryHandler<IUnitOfWork, TEntityModel, TReadModel>);
+            services.AddScoped(typeof(IRequestHandler<EntityPagedQuery<ResponseList<TReadModel>>, ResponseList<TReadModel>>), pagedQueryHandler);
+            #endregion
+        }
+    }
+}

--- a/DefaultCQRS/Authorization/ProductAuthorizationHandler.cs
+++ b/DefaultCQRS/Authorization/ProductAuthorizationHandler.cs
@@ -1,0 +1,18 @@
+using AlJawad.DefaultCQRS.CQRS.Permissions;
+using DefaultCQRS.Entities;
+using Microsoft.AspNetCore.Authorization;
+using System.Threading.Tasks;
+
+namespace DefaultCQRS.Authorization
+{
+    public class ProductAuthorizationHandler : AuthorizationHandler<BaseRequirement<Product, int>>
+    {
+        protected override Task HandleRequirementAsync(AuthorizationHandlerContext context, BaseRequirement<Product, int> requirement)
+        {
+            // For demonstration purposes, we'll just succeed.
+            // In a real application, you would implement your authorization logic here.
+            context.Succeed(requirement);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/DefaultCQRS/Program.cs
+++ b/DefaultCQRS/Program.cs
@@ -5,6 +5,10 @@ using System.Reflection;
 
 using Asp.Versioning;
 using Asp.Versioning.ApiExplorer;
+using AlJawad.DefaultCQRS.Extensions;
+using DefaultCQRS.Entities;
+using DefaultCQRS.DTOs;
+using DefaultCQRS.Authorization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -14,6 +18,14 @@ builder.Services.AddDbContext<AppDbContext>(options =>
 
 builder.Services.AddAutoMapper(Assembly.GetExecutingAssembly());
 builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(GeneralHandlerInitializer).Assembly));
+
+// Register the dynamic CQRS handlers for the Product entity
+builder.Services.AddEntityDynamicConfiguration<Product, int, CreateProductDto, UpdateProductDto, ProductDto, ProductAuthorizationHandler>(builder.Configuration, options =>
+{
+    // Example of overriding a handler:
+    // options.CreateCommandHandler = typeof(MyCustomCreateProductCommandHandler);
+});
+
 builder.Services.AddControllers();
 builder.Services.AddRazorPages();
 


### PR DESCRIPTION
This commit introduces a new pattern for registering CQRS handlers that allows for overriding the default implementations.

- A new `EntityHandlersConfiguration` class is added to specify custom handler types.
- The `AddEntityDynamicConfiguration` extension method is created to register handlers based on the provided configuration, with fallbacks to default handlers.
- An example is added to `Program.cs` to demonstrate how to use the new configurable registration for the `Product` entity.
- A `ProductAuthorizationHandler` is added to support the example implementation.